### PR TITLE
allows PrtScn key as an additional shortcut key

### DIFF
--- a/vsproject/src/lib/modaldialogbox/hotcombo.h
+++ b/vsproject/src/lib/modaldialogbox/hotcombo.h
@@ -72,7 +72,7 @@ static vkey virtualkeys[] =
 // дополнительный набор виртуалкеев
 #define ADDVKCOUNT sizeof addvkeys / sizeof addvkeys[0]
 static vkey addvkeys[] =
-    {   {0x00, ""}, {0x09, "Tab"}, {0x0D, "Enter"}, {0x5D, "Menu"} };
+    {   {0x00, ""}, {0x09, "Tab"}, {0x0D, "Enter"}, {0x5D, "Menu"}, {0x2C, "PrtScn"} };
 
 /***********************************************************************************************************/
 /* сабклассинг комбо */


### PR DESCRIPTION
Partly resolves #9 by adding the PrtScn virtual keycode `0x2C` to the additional shortcut key collection `addvkeys[]` since adding it to `virtualkeys[]` doesn't work.